### PR TITLE
Templates - initial trimou support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <version.mustache>0.9.0</version.mustache>
         <version.freemarker>2.3.23</version.freemarker>
+        <version.trimou>1.8.2.Final</version.trimou>
     </properties>
 
     <dependencies>
@@ -113,6 +114,14 @@
             <version>${version.freemarker}</version>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>org.trimou</groupId>
+            <artifactId>trimou-core</artifactId>
+            <version>${version.trimou}</version>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Test dependencies -->
 
         <dependency>

--- a/src/main/java/io/undertow/js/templates/trimou/TrimouTemplateProvider.java
+++ b/src/main/java/io/undertow/js/templates/trimou/TrimouTemplateProvider.java
@@ -1,0 +1,52 @@
+package io.undertow.js.templates.trimou;
+
+import java.util.Map;
+
+import org.trimou.Mustache;
+import org.trimou.engine.MustacheEngine;
+import org.trimou.engine.MustacheEngineBuilder;
+import org.trimou.engine.config.EngineConfigurationKey;
+import org.trimou.handlebars.HelpersBuilder;
+
+import io.undertow.js.templates.Template;
+import io.undertow.js.templates.TemplateProvider;
+
+/**
+ * TODO Right now, a new provider is created for each handler. Maybe it would be better to cache provider instances.
+ *
+ * @author Martin Kouba
+ */
+public class TrimouTemplateProvider implements TemplateProvider {
+
+    private MustacheEngine engine;
+
+    @Override
+    public String name() {
+        return "trimou";
+    }
+
+    @Override
+    public void init(Map<String, String> properties) {
+        // TODO Currently, it's not possible to use the template cache, i.e. partials and template inheritance will not work - we would have to provide a
+        // special template locator, probably using the deployment ResourceManager
+        engine = MustacheEngineBuilder.newBuilder().registerHelpers(HelpersBuilder.extra().build())
+                .setProperty(EngineConfigurationKey.DEBUG_MODE, Boolean.parseBoolean(properties.get("debug")))
+                .setProperty(EngineConfigurationKey.DEFAULT_FILE_ENCODING, properties.containsKey("charset") ? properties.get("charset") : "UTF-8").build();
+    }
+
+    @Override
+    public Template compile(String templateName, String templateContents) {
+        final Mustache mustache = engine.compileMustache(templateName, templateContents);
+        return new Template() {
+            @Override
+            public String apply(Object data) {
+                return mustache.render(data);
+            }
+        };
+    }
+
+    @Override
+    public void close() {
+    }
+
+}

--- a/src/main/resources/META-INF/services/io.undertow.js.templates.TemplateProvider
+++ b/src/main/resources/META-INF/services/io.undertow.js.templates.TemplateProvider
@@ -1,2 +1,3 @@
 io.undertow.js.templates.mustache.MustacheTemplateProvider
 io.undertow.js.templates.freemarker.FreemarkerTemplateProvider
+io.undertow.js.templates.trimou.TrimouTemplateProvider

--- a/src/test/java/io/undertow/js/test/templates/trimou/TrimouTemplateTestCase.java
+++ b/src/test/java/io/undertow/js/test/templates/trimou/TrimouTemplateTestCase.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.js.test.templates.trimou;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import javax.script.ScriptException;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.undertow.js.UndertowJS;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.resource.ClassPathResourceManager;
+import io.undertow.server.handlers.resource.ResourceHandler;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpClientUtils;
+import io.undertow.testutils.TestHttpClient;
+import io.undertow.util.StatusCodes;
+
+/**
+ * @author Martin Kouba
+ */
+@RunWith(DefaultServer.class)
+public class TrimouTemplateTestCase {
+
+    @BeforeClass
+    public static void setup() throws ScriptException, IOException {
+
+        final ClassPathResourceManager res = new ClassPathResourceManager(TrimouTemplateTestCase.class.getClassLoader(),
+                TrimouTemplateTestCase.class.getPackage());
+        UndertowJS js = UndertowJS.builder().addResources(res, "trimou.js").setResourceManager(res).build();
+        js.start();
+        DefaultServer.setRootHandler(js.getHandler(new ResourceHandler(res, new HttpHandler() {
+            @Override
+            public void handleRequest(HttpServerExchange exchange) throws Exception {
+                exchange.getResponseSender().send("Default Response");
+            }
+        })));
+    }
+
+    @Test
+    public void testSimpleMustacheTemplate() throws IOException {
+        final TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/testTemplate1");
+            HttpResponse result = client.execute(get);
+            assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            assertEquals("Template Data: Some Data", HttpClientUtils.readResponse(result));
+            assertEquals("text/html; charset=UTF-8", result.getFirstHeader("Content-Type").getValue());
+
+            get = new HttpGet(DefaultServer.getDefaultServerURL() + "/testTemplate2");
+            result = client.execute(get);
+            assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            assertEquals("Template Data: Some Data  a1-b1  a2-b2 ", HttpClientUtils.readResponse(result));
+            assertEquals("text/plain; charset=UTF-8", result.getFirstHeader("Content-Type").getValue());
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void testSimpleHandlebarsTemplate() throws IOException {
+        final TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/testTemplate3");
+            HttpResponse result = client.execute(get);
+            assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            assertEquals("Template Data: Some Data  a1-b1  a2-b2 ", HttpClientUtils.readResponse(result));
+            assertEquals("text/plain; charset=UTF-8", result.getFirstHeader("Content-Type").getValue());
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+}

--- a/src/test/java/io/undertow/js/test/templates/trimou/template1.txt
+++ b/src/test/java/io/undertow/js/test/templates/trimou/template1.txt
@@ -1,0 +1,1 @@
+Template Data: {{data}}

--- a/src/test/java/io/undertow/js/test/templates/trimou/template2.txt
+++ b/src/test/java/io/undertow/js/test/templates/trimou/template2.txt
@@ -1,0 +1,1 @@
+Template Data: {{data}} {{#loop}} {{foo}}-{{bar}} {{/loop}}

--- a/src/test/java/io/undertow/js/test/templates/trimou/template3.txt
+++ b/src/test/java/io/undertow/js/test/templates/trimou/template3.txt
@@ -1,0 +1,1 @@
+Template Data: {{data}} {{#each loop}} {{foo}}-{{bar}} {{/each}}

--- a/src/test/java/io/undertow/js/test/templates/trimou/trimou.js
+++ b/src/test/java/io/undertow/js/test/templates/trimou/trimou.js
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+$undertow
+    .setDefault('template_type', 'trimou')
+    .onGet("/testTemplate1", "template1.txt", function($exchange) {
+        return {data: "Some Data"};
+    })
+    .onGet("/testTemplate2", { template: "template2.txt", headers: {'Content-Type': "text/plain; charset=UTF-8", 'foo': 'bar'}}, function($exchange) {
+        return {data: "Some Data", loop: [{foo:'a1', bar: 'b1'}, {foo:'a2', bar: 'b2'}]};
+    })
+    .onGet("/testTemplate3", { template: "template3.txt", headers: {'Content-Type': "text/plain; charset=UTF-8", 'foo': 'bar'}}, function($exchange) {
+        return {data: "Some Data", loop: [{foo:'a1', bar: 'b1'}, {foo:'a2', bar: 'b2'}]};
+    });
+


### PR DESCRIPTION
I think it might be worth adding this support (however, as the author I'm a little bit biased ;-).
- Trimou is a Mustache implementation but also includes helpers API inspired by [Handlebars.js](http://handlebarsjs.com/)
- it has many extension points and several extensions are available out of the box (e.g. CDI)
- it's available under the Apache License 2.0
- Trimou core has three dependencies: commons-lang3, guava and slf4j (I'm not sure if this might be a problem)
- see also http://trimou.org
