### PR TITLE
CDIInjectionProvider modifications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,9 @@
         <serverPort>7777</serverPort>
         <proxy>false</proxy>
         <test.ipv6>false</test.ipv6>
-
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <!-- Versions -->
         <version.io.undertow>1.3.0.Beta6</version.io.undertow>
         <version.org.jboss.spec.javax.websocket>1.1.1.Final</version.org.jboss.spec.javax.websocket>
         <version.org.jboss.logging>1.2.0.Final</version.org.jboss.logging>
@@ -49,9 +51,7 @@
         <version.org.jboss.logmanager>1.5.3.Final</version.org.jboss.logmanager>
         <version.xnio>3.3.0.Final</version.xnio>
         <version.javax.enterprise.api>1.1</version.javax.enterprise.api>
-
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <version.weld>2.3.1.Final</version.weld>
         <version.mustache>0.9.0</version.mustache>
         <version.freemarker>2.3.23</version.freemarker>
         <version.trimou>1.8.2.Final</version.trimou>
@@ -163,6 +163,13 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
             <version>${version.com.h2}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.weld.servlet</groupId>
+            <artifactId>weld-servlet-core</artifactId>
+            <scope>test</scope>
+            <version>${version.weld}</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/io/undertow/js/providers/cdi/CDIInjectionProvider.java
+++ b/src/main/java/io/undertow/js/providers/cdi/CDIInjectionProvider.java
@@ -1,46 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package io.undertow.js.providers.cdi;
-
-import io.undertow.js.InjectionProvider;
 
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.CDI;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 
+import io.undertow.js.InjectionProvider;
+
+/**
+ *
+ * @author Stuart Douglas
+ * @author Martin Kouba
+ *
+ */
 public final class CDIInjectionProvider implements InjectionProvider {
 
-        @Override
-        public Object getObject(String name) {
-            try {
-                BeanManager beanManager = (BeanManager) new InitialContext().lookup("java:comp/BeanManager");
-                Bean<?> bean = beanManager.resolve(beanManager.getBeans(name));
+    private volatile BeanManager beanManager;
 
-                Class<?> t = Object.class;
-                Type realType = t;
-                for (Type type : bean.getTypes()) {
-                    Class c;
-                    if(type instanceof Class) {
-                        c = (Class) type;
-                    } else if(type instanceof ParameterizedType) {
-                        c = (Class)((ParameterizedType) type).getRawType();
-                    } else {
-                        continue;
-                    }
-                    if(t.isAssignableFrom(c)) {
-                        t = c;
-                        realType = type;
-                    }
-                }
-                return beanManager.getReference(bean, realType, beanManager.createCreationalContext(bean));
-            } catch (NamingException e) {
-                throw new RuntimeException(e);
+    @Override
+    public Object getObject(String name) {
+        if (beanManager == null) {
+            lookupBeanManager();
+        }
+        Bean<?> bean = beanManager.resolve(beanManager.getBeans(name));
+        return beanManager.getReference(bean, null, beanManager.createCreationalContext(bean));
+    }
+
+    @Override
+    public String getPrefix() {
+        return "cdi";
+    }
+
+    private synchronized void lookupBeanManager() {
+        if (beanManager == null) {
+            try {
+                beanManager = (BeanManager) new InitialContext().lookup("java:comp/BeanManager");
+            } catch (NamingException ignored) {
+            }
+            if (beanManager == null) {
+                beanManager = CDI.current().getBeanManager();
+            }
+            if (beanManager == null) {
+                throw new RuntimeException("Unable to lookup BeanManager");
             }
         }
-
-        @Override
-        public String getPrefix() {
-            return "cdi";
-        }
     }
+}

--- a/src/test/java/io/undertow/js/test/cdi/CDIInjectionProviderTestCase.java
+++ b/src/test/java/io/undertow/js/test/cdi/CDIInjectionProviderTestCase.java
@@ -1,0 +1,117 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.js.test.cdi;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import javax.script.ScriptException;
+import javax.servlet.ServletException;
+
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.jboss.weld.environment.Container;
+import org.jboss.weld.environment.servlet.Listener;
+import org.jboss.weld.environment.undertow.UndertowContainer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.undertow.js.UndertowJS;
+import io.undertow.js.providers.cdi.CDIInjectionProvider;
+import io.undertow.server.HandlerWrapper;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.handlers.PathHandler;
+import io.undertow.server.handlers.resource.ClassPathResourceManager;
+import io.undertow.servlet.Servlets;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.servlet.api.ServletContainer;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpClientUtils;
+import io.undertow.testutils.TestHttpClient;
+import io.undertow.util.StatusCodes;
+
+/**
+ *
+ * @author Martin Kouba
+ *
+ */
+@RunWith(DefaultServer.class)
+public class CDIInjectionProviderTestCase {
+
+    private UndertowJS undertowJs;
+
+    private DeploymentManager manager;
+
+    @Before
+    public void start() throws ScriptException, IOException, ServletException {
+
+        undertowJs = UndertowJS.builder()
+                .addInjectionProvider(new CDIInjectionProvider())
+                .addResources(new ClassPathResourceManager(CDIInjectionProviderTestCase.class.getClassLoader(), CDIInjectionProviderTestCase.class.getPackage()), "cdiinjection.js").build();
+        undertowJs.start();
+
+        final ServletContainer container = ServletContainer.Factory.newInstance();
+
+        DeploymentInfo builder = new DeploymentInfo()
+                .setClassLoader(CDIInjectionProviderTestCase.class.getClassLoader())
+                .addListener(Servlets.listener(Listener.class))
+                .addInitParameter(Container.CONTEXT_PARAM_CONTAINER_CLASS, UndertowContainer.class.getName())
+                .setContextPath("/cdiinject")
+                .setDeploymentName("cdiinject.war")
+                .addInnerHandlerChainWrapper(new HandlerWrapper() {
+                    @Override
+                    public HttpHandler wrap(HttpHandler handler) {
+                        return undertowJs.getHandler(handler);
+                    }
+                });
+
+        manager = container.addDeployment(builder);
+        manager.deploy();
+        PathHandler root = new PathHandler();
+        root.addPrefixPath(builder.getContextPath(), manager.start());
+
+        DefaultServer.setRootHandler(root);
+    }
+
+    @After
+    public void stop() throws ServletException {
+        manager.stop();
+        manager.undeploy();
+        undertowJs.stop();
+    }
+
+    @Test
+    public void testInjection() throws ClientProtocolException, IOException {
+        final TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/cdiinject/foo");
+            CloseableHttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            assertEquals("pong", HttpClientUtils.readResponse(result));
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+}

--- a/src/test/java/io/undertow/js/test/cdi/Foo.java
+++ b/src/test/java/io/undertow/js/test/cdi/Foo.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.js.test.cdi;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Named;
+
+@Named
+@RequestScoped
+public class Foo {
+
+    public String ping() {
+        return "pong";
+    }
+
+}

--- a/src/test/java/io/undertow/js/test/cdi/cdiinjection.js
+++ b/src/test/java/io/undertow/js/test/cdi/cdiinjection.js
@@ -1,0 +1,22 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+$undertow
+    .onGet("/foo", ['cdi:foo', function ($exchange, foo) {
+        return foo.ping();
+    }]);

--- a/src/test/resources/META-INF/beans.xml
+++ b/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.1" bean-discovery-mode="annotated">
+</beans>


### PR DESCRIPTION
- cache BeanManager
- fallback to CDI.current() if JNDI lookup fails
- do not identify the required type (weld doesn't use it for EL either),
  the only case where it is taken into consideration is a special case with
  unproxyable bean types (see also WELD-1052); should work with OWB too
- added test case
