### PR TITLE
Upgrade Trimou to 2.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,9 @@
         <version.weld>2.3.1.Final</version.weld>
         <version.mustache>0.9.0</version.mustache>
         <version.freemarker>2.3.23</version.freemarker>
-        <version.trimou>1.8.2.Final</version.trimou>
+        <version.trimou>2.0.1.Final</version.trimou>
+        <version.glassfish-el>3.0.0</version.glassfish-el>
+        <version.slf4j>1.7.4</version.slf4j>
     </properties>
 
     <modules>
@@ -137,6 +139,20 @@
                 <optional>true</optional>
             </dependency>
 
+            <dependency>
+                <groupId>org.trimou</groupId>
+                <artifactId>trimou-extension-cdi</artifactId>
+                <version>${version.trimou}</version>
+                <optional>true</optional>
+            </dependency>
+
+            <dependency>
+                <groupId>org.trimou</groupId>
+                <artifactId>trimou-extension-el</artifactId>
+                <version>${version.trimou}</version>
+                <optional>true</optional>
+            </dependency>
+
             <!-- Test dependencies -->
 
             <dependency>
@@ -160,12 +176,14 @@
                 <scope>test</scope>
                 <version>${version.org.junit}</version>
             </dependency>
+
             <dependency>
                 <groupId>org.jboss.logmanager</groupId>
                 <artifactId>jboss-logmanager</artifactId>
                 <scope>test</scope>
                 <version>${version.org.jboss.logmanager}</version>
             </dependency>
+
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
@@ -186,6 +204,28 @@
                 <scope>test</scope>
                 <version>${version.weld}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.jboss.weld.se</groupId>
+                <artifactId>weld-se-core</artifactId>
+                <scope>test</scope>
+                <version>${version.weld}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>javax.el</artifactId>
+                <scope>test</scope>
+                <version>${version.glassfish-el}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${version.slf4j}</version>
+                <scope>test</scope>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/templates/trimou/pom.xml
+++ b/templates/trimou/pom.xml
@@ -54,6 +54,18 @@
         <!-- Test dependencies -->
 
         <dependency>
+            <groupId>org.trimou</groupId>
+            <artifactId>trimou-extension-cdi</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.trimou</groupId>
+            <artifactId>trimou-extension-el</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>
             <type>test-jar</type>
@@ -71,15 +83,40 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.weld.servlet</groupId>
+            <artifactId>weld-servlet-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
         </dependency>
 
     </dependencies>

--- a/templates/trimou/src/test/java/io/undertow/js/test/templates/trimou/Foo.java
+++ b/templates/trimou/src/test/java/io/undertow/js/test/templates/trimou/Foo.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.js.test.templates.trimou;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Named;
+
+@Named
+@RequestScoped
+public class Foo {
+
+    public String getName() {
+        return "Vojta";
+    }
+
+    public String ping() {
+        return "pong";
+    }
+
+}

--- a/templates/trimou/src/test/java/io/undertow/js/test/templates/trimou/TrimouExtensionsTemplateTestCase.java
+++ b/templates/trimou/src/test/java/io/undertow/js/test/templates/trimou/TrimouExtensionsTemplateTestCase.java
@@ -1,0 +1,138 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.js.test.templates.trimou;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import javax.script.ScriptException;
+import javax.servlet.ServletException;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.jboss.weld.environment.Container;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.jboss.weld.environment.servlet.Listener;
+import org.jboss.weld.environment.servlet.WeldServletLifecycle;
+import org.jboss.weld.environment.undertow.UndertowContainer;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.undertow.js.UndertowJS;
+import io.undertow.js.templates.trimou.TrimouTemplateProvider;
+import io.undertow.server.HandlerWrapper;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.handlers.PathHandler;
+import io.undertow.server.handlers.resource.ClassPathResourceManager;
+import io.undertow.servlet.Servlets;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.servlet.api.ServletContainer;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpClientUtils;
+import io.undertow.testutils.TestHttpClient;
+import io.undertow.util.StatusCodes;
+
+/**
+ *
+ * @author Martin Kouba
+ *
+ */
+@RunWith(DefaultServer.class)
+public class TrimouExtensionsTemplateTestCase {
+
+    private static UndertowJS undertowJs;
+
+    private static DeploymentManager manager;
+
+    private static WeldContainer weldContainer;
+
+    @BeforeClass
+    public static void setup()
+            throws ScriptException, IOException, ServletException {
+
+        ClassPathResourceManager resourceManager = new ClassPathResourceManager(
+                TrimouTemplateTestCase.class.getClassLoader(),
+                TrimouExtensionsTemplateTestCase.class.getPackage());
+
+        // CDI extension expects the container to be already started
+        weldContainer = new Weld().initialize();
+
+        undertowJs = UndertowJS.builder()
+                .addTemplateProvider(new TrimouTemplateProvider())
+                .addResources(resourceManager, "trimou.js")
+                .setResourceManager(resourceManager).build();
+        undertowJs.start();
+
+        ServletContainer container = ServletContainer.Factory
+                .newInstance();
+
+        DeploymentInfo builder = new DeploymentInfo()
+                .setClassLoader(
+                        TrimouExtensionsTemplateTestCase.class.getClassLoader())
+                .addListener(Servlets.listener(Listener.class))
+                .addInitParameter(Container.CONTEXT_PARAM_CONTAINER_CLASS,
+                        UndertowContainer.class.getName())
+                // Reuse the BeanManager from Weld SE
+                .addServletContextAttribute(
+                        WeldServletLifecycle.BEAN_MANAGER_ATTRIBUTE_NAME,
+                        weldContainer.getBeanManager())
+                .setContextPath("/ext")
+                .setDeploymentName("trimou-extensions.war")
+                .addInnerHandlerChainWrapper(new HandlerWrapper() {
+                    @Override
+                    public HttpHandler wrap(HttpHandler handler) {
+                        return undertowJs.getHandler(handler);
+                    }
+                });
+
+        manager = container.addDeployment(builder);
+        manager.deploy();
+        PathHandler root = new PathHandler();
+        root.addPrefixPath(builder.getContextPath(), manager.start());
+
+        DefaultServer.setRootHandler(root);
+    }
+
+    @AfterClass
+    public static void teardown() throws ServletException {
+        weldContainer.shutdown();
+        manager.stop();
+        manager.undeploy();
+        undertowJs.stop();
+    }
+
+    @Test
+    public void testExtensions()
+            throws IOException, ScriptException, ServletException {
+        try (TestHttpClient client = new TestHttpClient()) {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL()
+                    + "/ext/testTemplateExtensions");
+            CloseableHttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK,
+                    result.getStatusLine().getStatusCode());
+            assertEquals("pong", HttpClientUtils.readResponse(result).trim());
+        }
+    }
+
+}

--- a/templates/trimou/src/test/java/io/undertow/js/test/templates/trimou/template_extensions.txt
+++ b/templates/trimou/src/test/java/io/undertow/js/test/templates/trimou/template_extensions.txt
@@ -1,0 +1,3 @@
+{{#if "not empty foo.name"}}
+    {{foo.ping}}
+{{/if}}

--- a/templates/trimou/src/test/java/io/undertow/js/test/templates/trimou/trimou.js
+++ b/templates/trimou/src/test/java/io/undertow/js/test/templates/trimou/trimou.js
@@ -29,5 +29,8 @@ $undertow
     })
     .onGet("/testTemplatePartial", "template_partial.txt", function($exchange) {
         return {data: "Some Data"};
+    })
+    .onGet("/testTemplateExtensions", "template_extensions.txt", function($exchange) {
+        return {data: "Dummy"};
     });
 

--- a/templates/trimou/src/test/resources/META-INF/beans.xml
+++ b/templates/trimou/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.1" bean-discovery-mode="annotated">
+</beans>


### PR DESCRIPTION
- add test for CDI and EL extensions
- Trimou 2 highlights: reduced footprint (got rid of guava and commons-lang), requires Java 8, EL extension:
  - https://github.com/trimou/trimou/releases/tag/2.0.0.Final
  - https://github.com/trimou/trimou/releases/tag/2.0.1.Final
