### PR TITLE
Update dependancies to latest to make sure it works with latest undertow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>19</version>
+        <version>24</version>
     </parent>
 
     <groupId>io.undertow.js</groupId>
@@ -40,20 +40,18 @@
         <serverPort>7777</serverPort>
         <proxy>false</proxy>
         <test.ipv6>false</test.ipv6>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
         <!-- Versions -->
-        <version.io.undertow>1.3.0.Beta6</version.io.undertow>
+        <version.io.undertow>1.4.18.Final</version.io.undertow>
         <version.org.jboss.spec.javax.websocket>1.1.1.Final</version.org.jboss.spec.javax.websocket>
         <version.org.jboss.logging>1.2.0.Final</version.org.jboss.logging>
         <version.org.apache.httpcomponents>4.3.6</version.org.apache.httpcomponents>
         <version.com.h2>1.4.181</version.com.h2>
-        <version.org.junit>4.11</version.org.junit>
+        <version.org.junit>4.12</version.org.junit>
         <version.org.jboss.logmanager>1.5.3.Final</version.org.jboss.logmanager>
-        <version.xnio>3.3.0.Final</version.xnio>
+        <version.xnio>3.3.8.Final</version.xnio>
         <version.javax.enterprise.api>1.1</version.javax.enterprise.api>
-        <version.weld>2.3.1.Final</version.weld>
-        <version.mustache>0.9.0</version.mustache>
+        <version.weld>2.4.3.Final</version.weld>
+        <version.mustache>0.9.5</version.mustache>
         <version.freemarker>2.3.23</version.freemarker>
         <version.trimou>1.8.2.Final</version.trimou>
     </properties>


### PR DESCRIPTION
fixes:

```
16:07:13,590 ERROR [io.undertow.request] (default task-25) UT005071: Undertow request failed HttpServerExchange{ POST /kitchensink-utjs-angularjs/rest/members request {Accept=[application/json, text/plain, */*], X-Requested-
With=[XMLHttpRequest], Accept-Language=[en-US,en;q=0.5], Accept-Encoding=[gzip, deflate], DNT=[1], User-Agent=[Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:54.0) Gecko/20100101 Firefox/54.0], Connection=[keep-alive], Content
-Type=[application/json;charset=utf-8], Content-Length=[63], Referer=[http://localhost:8080/kitchensink-utjs-angularjs/], Host=[localhost:8080]} response {X-Powered-By=[Undertow/1], Server=[JBoss-EAP/7]}}: java.lang.NoSuchMe
thodError: io.undertow.servlet.api.Deployment.getThreadSetupAction()Lio/undertow/servlet/core/CompositeThreadSetupAction;
        at io.undertow.js//io.undertow.js.UndertowJSServletExtension$1$1.handleRequest(UndertowJSServletExtension.java:94)
        at io.undertow.core//io.undertow.server.Connectors.executeRootHandler(Connectors.java:211)
        at io.undertow.js//io.undertow.js.StringReadHandler$1$1.stringDone(StringReadHandler.java:58)
```